### PR TITLE
Add option for exporting grades in JSON

### DIFF
--- a/src/components/Header.vue
+++ b/src/components/Header.vue
@@ -555,7 +555,7 @@
           <b-dropdown-item
             v-b-tooltip.hover.left.v-dark
             href="#"
-            title="ייצוא מערכת קורסים(ללא ציונים)"
+            title="ייצוא מערכת קורסים (עם ציונים)"
             @click="exportAsJson"
           >
             <font-awesome-icon
@@ -569,9 +569,30 @@
                 font-size: 20px;
                 margin-top: 10px;
               "
-              title="ייצוא מערכת קורסים(ללא ציונים)"
+              title="ייצוא מערכת קורסים (עם ציונים)"
             />
             יצוא קורסים לקובץ-JSON
+          </b-dropdown-item>
+          <b-dropdown-item
+            v-b-tooltip.hover.left.v-dark
+            href="#"
+            title="ייצוא מערכת קורסים (ללא ציונים)"
+            @click="exportAsJsonNoGrades"
+          >
+            <font-awesome-icon
+              href="#"
+              icon="download"
+              size="lg"
+              style="
+                color: lightgray;
+                margin-right: 5px;
+                margin-left: 5px;
+                font-size: 20px;
+                margin-top: 10px;
+              "
+              title="ייצוא מערכת קורסים (ללא ציונים)"
+            />
+            יצוא קורסים ללא ציונים לקובץ-JSON
           </b-dropdown-item>
           <b-dropdown-item v-b-modal.modal-import-from-json href="#">
             <font-awesome-icon
@@ -773,6 +794,9 @@ export default {
     },
     exportAsJson() {
       this.$store.commit("exportSemesters");
+    },
+    exportAsJsonNoGrades() {
+      this.$store.commit("exportSemestersNoGrades");
     },
     importCourseFromUG() {
       return this.importCoursesFromSite("UG");

--- a/src/store/store.js
+++ b/src/store/store.js
@@ -542,13 +542,23 @@ export const store = new Vuex.Store({
         });
       }
     },
-    exportSemesters: (state) => {
+    exportSemestersNoGrades: (state) => {
       let copy = JSON.stringify(state.user.semesters);
       copy = JSON.parse(copy);
       for (let sem of copy) {
         for (let course of sem.courses) {
           course.grade = 0;
         }
+        calculatePoints(sem);
+        calculateAverage(sem);
+      }
+      let data = JSON.stringify(copy, undefined, 2);
+      saveJSON(data, "courses.json");
+    },
+    exportSemesters: (state) => {
+      let copy = JSON.stringify(state.user.semesters);
+      copy = JSON.parse(copy);
+      for (let sem of copy) {
         calculatePoints(sem);
         calculateAverage(sem);
       }


### PR DESCRIPTION
Add an option to export courses as JSON while keeping the grades, so now the "..." dropdown looks like this:
![image](https://user-images.githubusercontent.com/57037062/147298345-b5ed2853-a1c4-40df-a871-80663cfd3515.png)
